### PR TITLE
feat: Configure Docker Compose for Kong + PostgreSQL + Redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ Thumbs.db
 
 # Docker
 docker-compose.override.yml
+
+# SSL certificates (generated locally)
+ssl/*.crt
+ssl/*.key
+ssl/*.pem
+!ssl/.gitkeep

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,70 @@
+version: '3.8'
+
+# Kong Gateway Production Overlay
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Production differences:
+# - No exposed ports for database
+# - Resource limits
+# - Replicas for Kong
+# - External database option
+
+services:
+  kong-db:
+    # In production, consider using managed PostgreSQL (RDS, Cloud SQL)
+    # Comment out this service if using external database
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 256M
+    ports: []  # Don't expose database in production
+
+  kong:
+    deploy:
+      mode: replicated
+      replicas: 2
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+      update_config:
+        parallelism: 1
+        delay: 10s
+        order: start-first
+      rollback_config:
+        parallelism: 1
+        delay: 10s
+    environment:
+      # Production logging
+      KONG_LOG_LEVEL: warn
+
+      # Performance tuning
+      KONG_NGINX_WORKER_PROCESSES: auto
+      KONG_UPSTREAM_KEEPALIVE_POOL_SIZE: 512
+
+      # Security
+      KONG_ADMIN_LISTEN: 127.0.0.1:8001  # Admin only on localhost
+
+  redis:
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 128M
+    ports: []  # Don't expose Redis in production
+
+  # ===========================================
+  # Optional: Kong Manager UI (Enterprise feature)
+  # ===========================================
+  # kong-manager:
+  #   image: kong/kong-gateway:3.5
+  #   environment:
+  #     KONG_ADMIN_GUI_URL: https://manager.api.abm.dev
+  #   depends_on:
+  #     - kong

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,149 @@
+version: '3.8'
+
+# Kong Gateway Docker Compose Configuration
+# Local development setup with PostgreSQL, Redis, and Kong OSS 3.5
+#
+# Ports (avoid conflicts with abm.dev-platform):
+#   - Kong Proxy: 8080 (abm.dev-platform uses 8000)
+#   - Kong Admin: 8081
+#   - PostgreSQL: 5434 (abm.dev-platform uses 5433)
+#   - Redis: 6380
+
+services:
+  # ===========================================
+  # PostgreSQL Database for Kong
+  # ===========================================
+  kong-db:
+    image: postgres:15-alpine
+    container_name: kong-db
+    environment:
+      POSTGRES_USER: ${KONG_PG_USER:-kong}
+      POSTGRES_PASSWORD: ${KONG_PG_PASSWORD:-kongpassword}
+      POSTGRES_DB: ${KONG_PG_DATABASE:-kong}
+    volumes:
+      - kong-db-data:/var/lib/postgresql/data
+    ports:
+      - "5434:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${KONG_PG_USER:-kong}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - kong-net
+    restart: unless-stopped
+
+  # ===========================================
+  # Kong Database Migrations
+  # ===========================================
+  kong-migrations:
+    image: kong:3.5
+    container_name: kong-migrations
+    command: kong migrations bootstrap
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_HOST: kong-db
+      KONG_PG_USER: ${KONG_PG_USER:-kong}
+      KONG_PG_PASSWORD: ${KONG_PG_PASSWORD:-kongpassword}
+      KONG_PG_DATABASE: ${KONG_PG_DATABASE:-kong}
+    depends_on:
+      kong-db:
+        condition: service_healthy
+    networks:
+      - kong-net
+    restart: on-failure
+
+  # ===========================================
+  # Kong Gateway
+  # ===========================================
+  kong:
+    image: kong:3.5
+    container_name: kong
+    environment:
+      # Database configuration
+      KONG_DATABASE: postgres
+      KONG_PG_HOST: kong-db
+      KONG_PG_USER: ${KONG_PG_USER:-kong}
+      KONG_PG_PASSWORD: ${KONG_PG_PASSWORD:-kongpassword}
+      KONG_PG_DATABASE: ${KONG_PG_DATABASE:-kong}
+
+      # Proxy configuration
+      KONG_PROXY_LISTEN: 0.0.0.0:8000, 0.0.0.0:8443 ssl
+      KONG_ADMIN_LISTEN: 0.0.0.0:8001
+
+      # Logging
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+
+      # Declarative config (loaded after DB mode)
+      KONG_DECLARATIVE_CONFIG: /etc/kong/kong.yml
+
+      # Plugins
+      KONG_PLUGINS: bundled
+
+      # SSL (for development)
+      KONG_SSL_CERT: /etc/kong/ssl/kong.crt
+      KONG_SSL_CERT_KEY: /etc/kong/ssl/kong.key
+    volumes:
+      - ./kong.yml:/etc/kong/kong.yml:ro
+      - ./ssl:/etc/kong/ssl:ro
+    ports:
+      - "${KONG_PROXY_PORT:-8080}:8000"
+      - "${KONG_ADMIN_PORT:-8081}:8001"
+      - "${KONG_PROXY_SSL_PORT:-8443}:8443"
+    depends_on:
+      kong-db:
+        condition: service_healthy
+      kong-migrations:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - kong-net
+      - abm-dev-network
+    restart: unless-stopped
+
+  # ===========================================
+  # Redis for Rate Limiting
+  # ===========================================
+  redis:
+    image: redis:7-alpine
+    container_name: kong-redis
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+    ports:
+      - "${REDIS_PORT:-6380}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - kong-net
+    restart: unless-stopped
+
+# ===========================================
+# Networks
+# ===========================================
+networks:
+  kong-net:
+    driver: bridge
+    name: kong-net
+  abm-dev-network:
+    external: true
+    name: abm-dev-network
+
+# ===========================================
+# Volumes
+# ===========================================
+volumes:
+  kong-db-data:
+    name: kong-db-data
+  redis-data:
+    name: kong-redis-data

--- a/kong.yml
+++ b/kong.yml
@@ -1,0 +1,58 @@
+_format_version: "3.0"
+_transform: true
+
+# Kong Gateway Declarative Configuration
+# ABM.dev API Gateway
+#
+# This file defines services, routes, plugins, and consumers.
+# Full route configuration will be added in Issue #4.
+
+# ===========================================
+# Services (Upstream APIs)
+# ===========================================
+services:
+  # Main ABM.dev Backend API
+  - name: abmdev-backend
+    url: ${ABMDEV_API_URL:-http://host.docker.internal:8000}
+    connect_timeout: 60000
+    write_timeout: 60000
+    read_timeout: 120000
+    retries: 2
+
+# ===========================================
+# Routes (Public - No Auth)
+# ===========================================
+routes:
+  # Health check - public
+  - name: health-check
+    service: abmdev-backend
+    paths:
+      - /health
+    methods:
+      - GET
+    strip_path: false
+
+  # Root welcome - public
+  - name: root
+    service: abmdev-backend
+    paths:
+      - /
+    methods:
+      - GET
+    strip_path: false
+
+# ===========================================
+# Global Plugins
+# ===========================================
+plugins:
+  # Correlation ID for request tracing
+  - name: correlation-id
+    config:
+      header_name: x-correlation-id
+      generator: uuid#counter
+      echo_downstream: true
+
+# ===========================================
+# Consumers (to be expanded in Issue #5-6)
+# ===========================================
+consumers: []

--- a/ssl/.gitkeep
+++ b/ssl/.gitkeep
@@ -1,0 +1,2 @@
+# SSL certificates directory
+# Run `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout kong.key -out kong.crt -subj "/CN=localhost"` to generate


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with Kong Gateway 3.5, PostgreSQL 15, and Redis 7
- Add `docker-compose.prod.yml` production overlay with resource limits and replicas
- Add minimal `kong.yml` declarative config (health/root routes for initial testing)
- Add `ssl/` directory for self-signed certificates
- Configure dual networks: `kong-net` (internal) and `abm-dev-network` (external)

## Port Mapping
| Service | Internal | External | Purpose |
|---------|----------|----------|---------|
| kong | 8000 | 8080 | API Proxy |
| kong admin | 8001 | 8081 | Admin API |
| kong-db | 5432 | 5434 | PostgreSQL |
| redis | 6379 | 6380 | Rate limiting |

## Services
- **kong-db**: PostgreSQL 15 for Kong state
- **kong-migrations**: Bootstrap database migrations
- **kong**: Kong Gateway 3.5 with health checks
- **redis**: Redis 7 for rate limiting storage

## Related Issues
- Closes #3 (Configure Docker Compose for Kong + PostgreSQL + Redis)
- Part of Epic #1: [Kong Gateway Infrastructure](https://github.com/abm-dev-git/kong-gateway/issues/1)

## Test Plan
- [ ] Verify `docker compose config` validates successfully
- [ ] Start services with `docker compose up -d`
- [ ] Check Kong admin: `curl localhost:8081/status`
- [ ] Check Kong proxy: `curl localhost:8080/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)