### PR TITLE
feat: Configure correlation-id and request-transformer plugins

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -610,11 +610,43 @@ routes:
 # ===========================================
 plugins:
   # Correlation ID for request tracing (all routes)
+  # Generates unique ID for each request for distributed tracing
   - name: correlation-id
+    tags:
+      - tracing
+      - correlation
     config:
       header_name: x-correlation-id
       generator: uuid#counter
       echo_downstream: true
+
+  # Post-function plugin to extract org_id from JWT claims
+  # Sets x-org-id header for rate limiting and backend authorization
+  # Note: This runs after JWT plugin validates the token
+  - name: post-function
+    tags:
+      - transformer
+      - org-id
+    config:
+      access:
+        - |
+          -- Extract org_id from JWT claims and set as header
+          local jwt_claims = kong.ctx.shared.authenticated_jwt_claims
+          if jwt_claims and jwt_claims.org_id then
+            kong.service.request.set_header("x-org-id", jwt_claims.org_id)
+            kong.log.debug("Set x-org-id header from JWT: ", jwt_claims.org_id)
+          else
+            -- Try to get org_id from API key consumer custom_id
+            local consumer = kong.client.get_consumer()
+            if consumer and consumer.custom_id then
+              -- Custom ID format: org_<id> for API key consumers
+              local org_id = consumer.custom_id
+              if org_id:sub(1, 4) == "org_" then
+                kong.service.request.set_header("x-org-id", org_id)
+                kong.log.debug("Set x-org-id header from consumer: ", org_id)
+              end
+            end
+          end
 
   # JWT Authentication Plugin (for authenticated routes)
   # Uses anonymous consumer fallback for Either/Or auth pattern


### PR DESCRIPTION
## Summary
Complete correlation-id configuration and add org_id extraction for rate limiting.

## Correlation-ID Plugin
- Generates unique UUID for each request
- Header: `x-correlation-id`
- Echoes downstream for response tracing

## Org-ID Extraction (post-function plugin)
Extracts organization ID and sets `x-org-id` header for:
- Per-org rate limiting
- Backend authorization

### Extraction Flow
1. **JWT Auth**: Extract `org_id` from JWT claims
2. **API Key Auth**: Extract from consumer's `custom_id` (format: `org_<id>`)

## Example Headers
```
Request:
  Authorization: Bearer <jwt_with_org_id_claim>
  
Added by Kong:
  x-correlation-id: 1234-5678-uuid
  x-org-id: org_abc123
```

## Related Issues
- Closes #8 (Configure correlation-id and request-transformer plugins)
- **Completes Epic #1**: [Kong Gateway Infrastructure](https://github.com/abm-dev-git/kong-gateway/issues/1)

## Test Plan
- [ ] Verify correlation-id in response: `curl -v localhost:8080/health 2>&1 | grep x-correlation-id`
- [ ] Verify org-id extraction with JWT
- [ ] Verify org-id extraction with API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)