### PR TITLE
feat(kong): expose /v1/webhooks/{subscriptions,events,event-types}

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -10,7 +10,7 @@ _transform: true
 #   memory:feedback_minimal_enrichment_surface
 #   docs/superpowers/plans/2026-05-04-production-readiness-launch-checklist.md
 #
-# Route summary (~45 routes total, was ~150):
+# Route summary (~49 routes total, was ~150):
 #   - Public:       4 (root, health, clerk webhook, stripe webhook)
 #   - Status:       1 (status — client SDK warm-up)
 #   - Auth ctx:     3 (auth/me, organizations/current, organizations/signup)
@@ -21,6 +21,8 @@ _transform: true
 #   - HubSpot CRM:  4 (properties, migration preview/execute, field-mappings)
 #   - Billing:      8 (packages, credits + history, subscription, checkout,
 #                       payments, transactions, usage)
+#   - Webhooks:     4 (subscriptions list+create, subscription get/patch/delete,
+#                       events poll, event-types catalogue)
 
 services:
   # Main ABM.dev Backend API (for authenticated routes)
@@ -874,6 +876,77 @@ routes:
         config:
           replace:
             uri: /api/v1/billing/usage/daily
+
+  # ── Webhook subscriptions (outbound) ─────────────────────────────────
+  # User-managed subscriptions to platform events. Backend lives at
+  # WebhookSubscriptionsController. Inbound third-party webhooks
+  # (Stripe / Clerk) are handled by webhook-stripe / webhook-clerk above.
+  - name: webhooks-subscriptions
+    service: abmdev-backend
+    paths:
+      - ~/v1/webhooks/subscriptions$
+    methods:
+      - GET
+      - POST
+    strip_path: false
+    tags:
+      - webhooks
+      - authenticated
+    plugins:
+      - name: request-transformer
+        config:
+          replace:
+            uri: /api/v1/webhooks/subscriptions
+
+  - name: webhooks-subscription-by-id
+    service: abmdev-backend
+    paths:
+      - ~/v1/webhooks/subscriptions/(?<id>[0-9a-fA-F-]{36})$
+    methods:
+      - GET
+      - PATCH
+      - DELETE
+    strip_path: false
+    tags:
+      - webhooks
+      - authenticated
+    plugins:
+      - name: request-transformer
+        config:
+          replace:
+            uri: /api/v1/webhooks/subscriptions/$(uri_captures.id)
+
+  - name: webhooks-events
+    service: abmdev-backend
+    paths:
+      - ~/v1/webhooks/events$
+    methods:
+      - GET
+    strip_path: false
+    tags:
+      - webhooks
+      - authenticated
+    plugins:
+      - name: request-transformer
+        config:
+          replace:
+            uri: /api/v1/webhooks/events
+
+  - name: webhooks-event-types
+    service: abmdev-backend
+    paths:
+      - ~/v1/webhooks/event-types$
+    methods:
+      - GET
+    strip_path: false
+    tags:
+      - webhooks
+      - authenticated
+    plugins:
+      - name: request-transformer
+        config:
+          replace:
+            uri: /api/v1/webhooks/event-types
 
 plugins:
   # CORS Plugin - Enable cross-origin requests from portal


### PR DESCRIPTION
## Summary

Backend ships the full outbound-webhook API (\`WebhookSubscriptionsController\` + \`WebhookDeliveryService\` — HMAC-SHA256 signing, exponential-backoff retries, auto-disable after 10 failures) but the gateway wasn't routing any of it. Public callers (Zapier REST hook, n8n, direct customer receivers) all 404 at api.abm.dev as a result.

## What changed
4 new routes on \`abmdev-backend\`, all transformed to \`/api/v1/webhooks/...\`:

| Method(s) | Path | Backend route |
|---|---|---|
| GET / POST | \`/v1/webhooks/subscriptions\` | list + create |
| GET / PATCH / DELETE | \`/v1/webhooks/subscriptions/{uuid}\` | get + update + delete |
| GET | \`/v1/webhooks/events\` | poll events |
| GET | \`/v1/webhooks/event-types\` | catalogue |

UUID path param constrained to the canonical 36-char \`[0-9a-fA-F-]\` form so the by-id route doesn't accidentally swallow \`/events\` or \`/event-types\`.

## Auth
No middleware changes needed — \`ApiKeyAuthenticationMiddleware\` on the backend reads \`x-api-key\`, looks up the API-key → org binding, and sets \`HttpContext.Items[\"OrganizationId\"]\` which the controller already reads. Identical to every other authenticated route.

## Note on history
These routes were briefly added in 1430589 (Apr 25) and removed in dd8df17 (May 6 "minimal enrichment surface" sweep) before any external caller depended on them. Reinstating now that the Zapier ship path needs them.

## Companion PRs
- \`kong-portal\` PR #156 — \`/api-reference/webhooks\` docs page
- \`abm-zapier-app\` — trigger swap from polling to REST hook (uncommitted, sibling repo, see \`/home/abm-dev/code/abm-zapier-app/triggers/enrichmentCompleted.js\`)

## Test plan
- [ ] \`docker exec kong kong config parse /etc/kong/kong.yml\` clean
- [ ] \`curl -s https://api.abm.dev/v1/webhooks/event-types -H \"x-api-key: \$KEY\" | jq\` returns the catalogue
- [ ] \`curl -X POST https://api.abm.dev/v1/webhooks/subscriptions -H \"x-api-key: \$KEY\" -d '{\"event_type\":\"enrichment.completed\",\"url\":\"https://webhook.site/abc\"}'\` returns a subscription with \`secret\`
- [ ] DELETE on the same id returns 200
- [ ] Inbound Stripe/Clerk webhooks at \`/v1/webhooks/stripe\` and \`/v1/webhooks/clerk\` still work (unchanged routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)