### PR TITLE
chore: rename Staging/Dev to Dev in comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ ABMDEV_API_URL=http://abm-dev-api:8080
 # Clerk Authentication (JWT)
 # ===========================================
 # Get these from Clerk Dashboard
-# Staging/Dev: magical-stag-51.clerk.accounts.dev
+# Dev: magical-stag-51.clerk.accounts.dev
 CLERK_JWKS_URL=https://magical-stag-51.clerk.accounts.dev/.well-known/jwks.json
 CLERK_ISSUER=https://magical-stag-51.clerk.accounts.dev
 

--- a/kong.yml
+++ b/kong.yml
@@ -1233,7 +1233,7 @@ consumers:
 #   `key` field below against that `iss` claim (key_claim_name: iss), so
 #   this MUST be the proxy URL, not the clerk.abm.dev CNAME host.
 #   Verified via GET https://api.clerk.com/v1/domains (2026-04-19).
-# Dev/staging issuer: https://magical-stag-51.clerk.accounts.dev
+# Dev issuer: https://magical-stag-51.clerk.accounts.dev
 #
 # The public key below was fetched from Clerk prod JWKS endpoint
 # (kid: ins_36XBbvwAspqFqEPDfPQ85VOtySB) via the portal proxy route


### PR DESCRIPTION
## Summary

There's only Dev and Production — no separate Staging environment. Replaces "Staging/Dev" → "Dev" in two comment blocks. No behavioural change.

## Test plan

- [ ] Comment-only edit; nothing runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)