### PR TITLE
feat(kong): expose /v1/billing/topup-options as a public route

### DIFF
--- a/kong.yml
+++ b/kong.yml
@@ -765,6 +765,22 @@ routes:
           replace:
             uri: /api/v1/billing/packages
 
+  - name: billing-topup-options
+    service: abmdev-public
+    paths:
+      - ~/v1/billing/topup-options$
+    methods:
+      - GET
+    strip_path: false
+    tags:
+      - billing
+      - public
+    plugins:
+      - name: request-transformer
+        config:
+          replace:
+            uri: /api/v1/billing/topup-options
+
   - name: billing-credits
     service: abmdev-backend
     paths:


### PR DESCRIPTION
## Summary
- Adds a `billing-topup-options` route to Kong's production declarative config
- Wires `~/v1/billing/topup-options$` (GET) → `abmdev-public` upstream → `/api/v1/billing/topup-options`
- Required by the FE marketing-page pricing preview which expects 3-currency ladders from this endpoint

## Why
Backend already implements the endpoint (`BillingController.GetTopUpOptions`, no auth attribute) and returns the canonical 5-pack × 3-currency ladder seeded earlier today via direct Stripe API calls. Until this route is in place, `https://api.abm.dev/v1/billing/topup-options` returns `no Route matched` and the FE falls back to its hardcoded ladder — checkout still works because the price IDs in fallback now match Stripe live exactly, but FE not hitting BE means we'd never see flag-driven price changes.

## Test plan
- [x] `yaml.safe_load` passes
- [x] Pattern mirrors `billing-packages` (only differences: path, service tag, upstream uri)
- [ ] After merge + Railway redeploy: `curl -s https://api.abm.dev/v1/billing/topup-options?currency=GBP` returns 5 options with `popular: true` on the Growth/500 pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)